### PR TITLE
update conduct email group

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -41,7 +41,7 @@ This code of conduct applies both within project spaces and in public spaces whe
 individual is representing the project or its community.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by
-contacting a project maintainer at [conduct@swiftserver.group](mailto:conduct@swiftserver.group). All complaints will be reviewed and
+contacting a project maintainer at [conduct@swiftserver.group](mailto:swift-server-conduct@group.apple.com). All complaints will be reviewed and
 investigated and will result in a response that is deemed necessary and appropriate to the
 circumstances. Maintainers are obligated to maintain confidentiality with regard to the reporter
 of an incident.


### PR DESCRIPTION
motivation: use consistent email across swift server projects

changes: set conduct email address to swift-server-conduct@group.apple.com