### PR TITLE
+ #21 Add LabelSanitizer in order to survive : in label names (e.g. from Vapor)

### DIFF
--- a/Sources/StatsdClient/StatsdClient.swift
+++ b/Sources/StatsdClient/StatsdClient.swift
@@ -367,12 +367,12 @@ private final class Client {
 ///
 /// By default `StatsdClient` uses the `StatsdLabelSanitizer`.
 public protocol LabelSanitizer {
-    /// Sanitize the passed in label to a Prometheus accepted value.
+    /// Sanitize the passed in label to a statsd accepted value.
     ///
     /// - parameters:
     ///     - label: The created label that needs to be sanitized.
     ///
-    /// - returns: A sanitized string that a Prometheus backend will accept.
+    /// - returns: A sanitized string that a statsd backend will accept.
     func sanitize(_ label: String) -> String
 }
 

--- a/Sources/StatsdClient/StatsdClient.swift
+++ b/Sources/StatsdClient/StatsdClient.swift
@@ -82,7 +82,7 @@ public final class StatsdClient: MetricsFactory {
     }
 
     private func make<Item>(label: String, dimensions: [(String, String)], registry: inout [String: Item], maker: (String, [(String, String)]) -> Item) -> Item {
-        let id = StatsdUtils.id(label: label, dimensions: dimensions, sanitizer: client.labelSanitizer)
+        let id = StatsdUtils.id(label: label, dimensions: dimensions, sanitizer: self.client.labelSanitizer)
         if let item = registry[id] {
             return item
         }

--- a/Tests/StatsdClientTests/StatsdClientTests+XCTest.swift
+++ b/Tests/StatsdClientTests/StatsdClientTests+XCTest.swift
@@ -35,6 +35,7 @@ extension StatsdClientTests {
             ("testGaugeDouble", testGaugeDouble),
             ("testRecorderInteger", testRecorderInteger),
             ("testRecorderDouble", testRecorderDouble),
+            ("testLabelSanitizer", testLabelSanitizer),
             ("testCouncurrency", testCouncurrency),
             ("testNumberOfConnections", testNumberOfConnections),
         ]


### PR DESCRIPTION
More details in the ticket.

This addresses label sanitization in the same manner as we decided back then to do it for prometheus ( https://github.com/MrLotU/SwiftPrometheus/commit/938b2a29be42e756959175315d87c978d9f8e64e ).

It allows Vapor apps to be used by default with swift-metrics + swift-statsd-client.

Resolves #21 