### PR TITLE
add 5.4 docker setup for CI

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,8 +17,11 @@ RUN apt-get update && apt-get install -y wget
 RUN apt-get update && apt-get install -y lsof dnsutils netcat-openbsd net-tools curl jq # used by integration tests
 
 # ruby and jazzy for docs generation
-RUN apt-get update && apt-get install -y ruby ruby-dev libsqlite3-dev
-RUN gem install jazzy --no-ri --no-rdoc
+RUN apt-get update && apt-get install -y ruby ruby-dev libsqlite3-dev build-essential
+# switch of gem docs building
+RUN echo "gem: --no-document" > ~/.gemrc
+# jazzy no longer works on xenial as ruby is too old.
+RUN if [ "${ubuntu_version}" != "xenial" ] ; then  gem install jazzy; fi
 
 # tools
 RUN mkdir -p $HOME/.tools

--- a/docker/docker-compose.2004.54.yaml
+++ b/docker/docker-compose.2004.54.yaml
@@ -1,0 +1,13 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-statsd-client:20.04-5.4
+    build:
+      args:
+        ubuntu_version: "focal"
+        swift_version: "5.4"
+
+  test:
+    image: swift-statsd-client:20.04-5.4


### PR DESCRIPTION
motivation: 5.4 is out!

changes: add docker compose setup for ubuntu 20.04 and 5.4 toolchain