### PR TITLE
Address deprecation warnings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,11 +25,13 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0" ..< "3.0.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.0"),
     ],
     targets: [
         .target(name: "StatsdClient", dependencies: [
             .product(name: "CoreMetrics", package: "swift-metrics"),
             .product(name: "NIO", package: "swift-nio"),
+            .product(name: "Atomics", package: "swift-atomics"),
         ]),
         .testTarget(name: "StatsdClientTests", dependencies: [
             .target(name: "StatsdClient"),

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -24,6 +24,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0" ..< "3.0.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
+        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.0"),
     ],
     targets: [
         .target(name: "StatsdClient", dependencies: ["CoreMetrics", "NIO"]),

--- a/Sources/StatsdClient/Atomics.swift
+++ b/Sources/StatsdClient/Atomics.swift
@@ -1,0 +1,64 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftStatsdClient open source project
+//
+// Copyright (c) 2019-2023 the SwiftStatsdClient project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftStatsdClient project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+#if canImport(Atomics)
+import Atomics
+#else
+import NIOConcurrencyHelpers
+#endif
+
+internal class Atomic<T: AtomicValue> {
+    #if canImport(Atomics)
+    private let managed: ManagedAtomic<T>
+    #else
+    private let nio: NIOAtomic<T>
+    #endif
+
+    init(_ value: T) {
+        #if canImport(Atomics)
+        self.managed = ManagedAtomic(value)
+        #else
+        self.nio = NIOAtomic.makeAtomic(value: value)
+        #endif
+    }
+
+    func load() -> T {
+        #if canImport(Atomics)
+        return self.managed.load(ordering: .sequentiallyConsistent)
+        #else
+        return self.nio.load()
+        #endif
+    }
+
+    func compareExchange(expected: T, desired: T) -> Bool {
+        #if canImport(Atomics)
+        return self.managed.compareExchange(
+            expected: expected,
+            desired: desired,
+            ordering: .sequentiallyConsistent
+        ).exchanged
+        #else
+        return self.nio.compareAndExchange(expected: expected, desired: desired)
+        #endif
+    }
+
+    func store(_ value: T) {
+        #if canImport(Atomics)
+        self.managed.store(value, ordering: .sequentiallyConsistent)
+        #else
+        self.nio.store(value)
+        #endif
+    }
+}

--- a/Sources/StatsdClient/Atomics.swift
+++ b/Sources/StatsdClient/Atomics.swift
@@ -25,7 +25,7 @@ internal class AtomicCounter {
     #else
     private let nio: NIOAtomic<Int64>
     #endif
-    
+
     init(_ value: Int64) {
         #if canImport(Atomics)
         self.managed = ManagedAtomic(value)
@@ -33,7 +33,7 @@ internal class AtomicCounter {
         self.nio = NIOAtomic.makeAtomic(value: value)
         #endif
     }
-    
+
     func load() -> Int64 {
         #if canImport(Atomics)
         return self.managed.load(ordering: .sequentiallyConsistent)
@@ -41,7 +41,7 @@ internal class AtomicCounter {
         return self.nio.load()
         #endif
     }
-    
+
     func compareExchange(expected: Int64, desired: Int64) -> Bool {
         #if canImport(Atomics)
         return self.managed.compareExchange(
@@ -53,7 +53,7 @@ internal class AtomicCounter {
         return self.nio.compareAndExchange(expected: expected, desired: desired)
         #endif
     }
-    
+
     func store(_ value: Int64) {
         #if canImport(Atomics)
         self.managed.store(value, ordering: .sequentiallyConsistent)

--- a/Sources/StatsdClient/StatsdClient.swift
+++ b/Sources/StatsdClient/StatsdClient.swift
@@ -24,8 +24,11 @@ public final class StatsdClient: MetricsFactory {
     private var counters = [String: CounterHandler]() // protected by a lock
     private var recorders = [String: RecorderHandler]() // protected by a lock
     private var timers = [String: TimerHandler]() // protected by a lock
+    #if swift(<5.5)
     private let lock = Lock()
-
+    #else
+    private let lock = NIOLock()
+    #endif
     /// Create a new instance of `StatsdClient`.
     ///
     /// - Parameters:
@@ -130,7 +133,7 @@ public final class StatsdClient: MetricsFactory {
 private final class StatsdCounter: CounterHandler, Equatable {
     let id: String
     let client: Client
-    var value = NIOAtomic<Int64>.makeAtomic(value: 0)
+    var value = Atomic<Int64>(0)
 
     init(label: String, dimensions: [(String, String)], client: Client) {
         self.id = StatsdUtils.id(label: label, dimensions: dimensions, sanitizer: client.metricNameSanitizer)
@@ -153,7 +156,8 @@ private final class StatsdCounter: CounterHandler, Equatable {
                 return // already at max
             }
             let newValue = oldValue.addingReportingOverflow(amount)
-            if self.value.compareAndExchange(expected: oldValue, desired: newValue.overflow ? Int64.max : newValue.partialValue) {
+
+            if self.value.compareExchange(expected: oldValue, desired: newValue.overflow ? Int64.max : newValue.partialValue) {
                 return
             }
         }
@@ -251,10 +255,14 @@ private final class Client {
 
     private let address: SocketAddress
 
-    private let isShutdown = NIOAtomic<Bool>.makeAtomic(value: false)
+    private let isShutdown = Atomic(false)
 
     private var state = State.disconnected
+    #if swift(<5.5)
     private let lock = Lock()
+    #else
+    private let lock = NIOLock()
+    #endif
 
     private enum State {
         case disconnected
@@ -285,7 +293,7 @@ private final class Client {
     func shutdown(_ callback: @escaping (Error?) -> Void) {
         switch self.eventLoopGroupProvider {
         case .createNew:
-            if self.isShutdown.compareAndExchange(expected: false, desired: true) {
+            if self.isShutdown.compareExchange(expected: false, desired: true) {
                 self.eventLoopGroup.shutdownGracefully(callback)
             }
         case .shared:

--- a/Sources/StatsdClient/StatsdClient.swift
+++ b/Sources/StatsdClient/StatsdClient.swift
@@ -133,7 +133,7 @@ public final class StatsdClient: MetricsFactory {
 private final class StatsdCounter: CounterHandler, Equatable {
     let id: String
     let client: Client
-    var value = Atomic<Int64>(0)
+    var value = AtomicCounter(0)
 
     init(label: String, dimensions: [(String, String)], client: Client) {
         self.id = StatsdUtils.id(label: label, dimensions: dimensions, sanitizer: client.metricNameSanitizer)
@@ -255,7 +255,7 @@ private final class Client {
 
     private let address: SocketAddress
 
-    private let isShutdown = Atomic(false)
+    private let isShutdown = AtomicBoolean(false)
 
     private var state = State.disconnected
     #if swift(<5.5)

--- a/Tests/StatsdClientTests/StatsdClientTests.swift
+++ b/Tests/StatsdClientTests/StatsdClientTests.swift
@@ -276,7 +276,11 @@ class StatsdClientTests: XCTestCase {
         let id = UUID().uuidString
 
         var results = [String]()
+        #if swift(<5.5)
+        let lock = Lock()
+        #else
         let lock = NIOLock()
+        #endif
 
         let group = DispatchGroup()
         server.onData { _, data in

--- a/Tests/StatsdClientTests/StatsdClientTests.swift
+++ b/Tests/StatsdClientTests/StatsdClientTests.swift
@@ -276,7 +276,7 @@ class StatsdClientTests: XCTestCase {
         let id = UUID().uuidString
 
         var results = [String]()
-        let lock = Lock()
+        let lock = NIOLock()
 
         let group = DispatchGroup()
         server.onData { _, data in

--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -19,7 +19,11 @@ here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function replace_acceptable_years() {
     # this needs to replace all acceptable forms with 'YEARS'
+<<<<<<< HEAD
+    sed -e 's/20[12][901]-202[0123]/YEARS/' -e 's/2019/YEARS/' -e 's/202[0123]/YEARS/'
+=======
     sed -e 's/20[12][901]-202[0123]/YEARS/' -e 's/2019/YEARS/' -e 's/202[012]/YEARS/'
+>>>>>>> origin/main
 }
 
 printf "=> Checking for unacceptable language... "

--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -19,11 +19,7 @@ here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function replace_acceptable_years() {
     # this needs to replace all acceptable forms with 'YEARS'
-<<<<<<< HEAD
     sed -e 's/20[12][901]-202[0123]/YEARS/' -e 's/2019/YEARS/' -e 's/202[0123]/YEARS/'
-=======
-    sed -e 's/20[12][901]-202[0123]/YEARS/' -e 's/2019/YEARS/' -e 's/202[012]/YEARS/'
->>>>>>> origin/main
 }
 
 printf "=> Checking for unacceptable language... "


### PR DESCRIPTION
- Rename `Lock` to `NIOLock`
- Replace uses of `NIOAtomic` with `ManagedAtomic`
- Bump copyright