### PR TITLE
Enable strict concurrency

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,8 +11,8 @@ jobs:
     name: Unit tests
     uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
     with:
-      linux_5_9_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
-      linux_5_10_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
+      linux_5_9_arguments_override: "--explicit-target-dependency-import-check error"
+      linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,8 +15,8 @@ jobs:
     name: Unit tests
     uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
     with:
-      linux_5_9_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
-      linux_5_10_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
+      linux_5_9_arguments_override: "--explicit-target-dependency-import-check error"
+      linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"

--- a/Package.swift
+++ b/Package.swift
@@ -44,3 +44,9 @@ let package = Package(
         ),
     ]
 )
+
+for target in package.targets {
+    var settings = target.swiftSettings ?? []
+    settings.append(.enableExperimentalFeature("StrictConcurrency=complete"))
+    target.swiftSettings = settings
+}

--- a/Tests/StatsdClientTests/StatsdClientIPV6Tests.swift
+++ b/Tests/StatsdClientTests/StatsdClientIPV6Tests.swift
@@ -23,9 +23,10 @@ import NIOCore
 
 private let host = "::1"
 private let port = 9999
-private var statsdClient: StatsdClient!
 
 class StatsdClientIPV6Tests: XCTestCase {
+    private var statsdClient: StatsdClient!
+
     override func setUp() {
         super.setUp()
 

--- a/Tests/StatsdClientTests/StatsdClientTests.swift
+++ b/Tests/StatsdClientTests/StatsdClientTests.swift
@@ -23,17 +23,18 @@ import class NIOConcurrencyHelpers.Lock
 
 private let host = "127.0.0.1"
 private let port = 9999
-private var statsdClient: StatsdClient!
 
 class StatsdClientTests: XCTestCase {
-    override class func setUp() {
+    private var statsdClient: StatsdClient!
+
+    override func setUp() {
         super.setUp()
 
         statsdClient = try! StatsdClient(host: host, port: port)
         MetricsSystem.bootstrapInternal(statsdClient)
     }
 
-    override class func tearDown() {
+    override func tearDown() {
         super.tearDown()
 
         let semaphore = DispatchSemaphore(value: 0)


### PR DESCRIPTION
### Motivation:

Catch potential data races at build time.

### Modifications:

- Enabled strict concurrency checking in the Package.swift.
- Made `StatsdClient` (and a few more non-public types) Sendable.

### Result:

Fewer potential data races can sneak in.

### Test Plan

Ran tests locally, did not see any concurrency warnings or errors.
