### PR TITLE
Address sendable warnings

### DIFF
--- a/Sources/StatsdClient/StatsdClient.swift
+++ b/Sources/StatsdClient/StatsdClient.swift
@@ -447,7 +447,7 @@ private final class Client: @unchecked Sendable {
         return bootstrap.bind(host: self.address.protocol == .inet6 ? "::" : "0.0.0.0", port: 0)
     }
 
-    private final class Encoder: ChannelOutboundHandler {
+    private final class Encoder: ChannelOutboundHandler, Sendable {
         public typealias OutboundIn = Metric
         public typealias OutboundOut = AddressedEnvelope<ByteBuffer>
 

--- a/Tests/StatsdClientTests/TestServer.swift
+++ b/Tests/StatsdClientTests/TestServer.swift
@@ -36,7 +36,9 @@ final class TestServer: @unchecked Sendable {
     func connect() -> EventLoopFuture<Void> {
         let bootstrap = DatagramBootstrap(group: self.eventLoopGroup)
             .channelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
-            .channelInitializer { channel in channel.pipeline.addHandler(Aggregator(delegate: { self.store(address: $0, value: $1) })) }
+            .channelInitializer { channel in
+                channel.pipeline.addHandler(Aggregator(delegate: { self.store(address: $0, value: $1) }))
+            }
 
         return bootstrap.bind(host: self.host, port: self.port).map { _ in () }
     }


### PR DESCRIPTION
Motivation:

Builds with newer Swift versions fail because the warnings are escalalated to errors.

Modifications:

* Make Encoder conform to Sendable.
* Fix Sendable issue in TestServer.

Result:

The project builds without warnings.